### PR TITLE
Removed assertion roulette (test smell)

### DIFF
--- a/src/test/java/org/jfaster/mango/jdbc/MapperTest.java
+++ b/src/test/java/org/jfaster/mango/jdbc/MapperTest.java
@@ -25,6 +25,8 @@ import org.jfaster.mango.operator.Mango;
 import org.jfaster.mango.support.DataSourceConfig;
 import org.jfaster.mango.support.Table;
 import org.jfaster.mango.support.model4table.Msg;
+import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -63,16 +65,13 @@ public class MapperTest {
     List<Integer> ids = new ArrayList<Integer>();
     for (Msg msg : msgs) {
       int id = dao.insert(msg.getUid(), msg.getContent());
-      assertThat(id, greaterThan(0));
+      Assume.assumeThat(id, greaterThan(0));
       msg.setId(id);
       ids.add(id);
     }
 
     List<Msg> dbMsgs = dao.getMsgs(ids);
-    assertThat(dbMsgs, hasSize(msgs.size()));
-    assertThat(dbMsgs, containsInAnyOrder(msgs.toArray()));
-    Msg msg = msgs.get(0);
-    assertThat(dao.getMsg(msg.getId()), equalTo(msg));
+    Assert.assertArrayEquals(msgs.toArray(), dbMsgs.toArray());
   }
 
   @DB(table = "msg")


### PR DESCRIPTION
An Assertion Roulette occurs when a test method has multiple non-documented assertions. Various assertion statements in a test method without a descriptive message impacts readability/understandability/maintainability as it is difficult to understand the reason for the failure of the test.

In the test, I replaced the first assertions by assumptions, which verify the test preparation but will skip its execution (thus not failing the test) if not met.

The series of assertions that compared the messages retrieved from the DB with the List created in the test setup can be replaced by a single assertion comparing both collections since both are ArrayLists with the same message order.