### PR TITLE
refactor: rename variables for better readability

### DIFF
--- a/src/main/java/org/jfaster/mango/annotation/DB.java
+++ b/src/main/java/org/jfaster/mango/annotation/DB.java
@@ -35,7 +35,7 @@ public @interface DB {
    *
    * @return
    */
-  String name() default AbstractDataSourceFactory.DEFULT_NAME;
+  String name() default AbstractDataSourceFactory.DEFAULT_NAME;
 
   /**
    * 全局表名，在{@link SQL}的字符串参数，可以通过#table的方式引用此全局表名。

--- a/src/main/java/org/jfaster/mango/crud/named/factory/AbstractNamedBuilderFactory.java
+++ b/src/main/java/org/jfaster/mango/crud/named/factory/AbstractNamedBuilderFactory.java
@@ -43,7 +43,7 @@ public abstract class AbstractNamedBuilderFactory extends BuilderFactory {
   @Nullable
   @Override
   public Builder doTryGetBuilder(String name, Type returnType, List<Type> parameterTypes, Class<?> entityClass, Class<?> idClass) {
-    int matchSize = metchSize(name);
+    int matchSize = matchSize(name);
     if (matchSize == 0) {
       return null;
     }
@@ -52,14 +52,14 @@ public abstract class AbstractNamedBuilderFactory extends BuilderFactory {
     return createCustomBuilder(name, parameterTypes, entityClass, info);
   }
 
-  public abstract List<String> prefixs();
+  public abstract List<String> prefixes();
 
   abstract AbstractNamedBuilder createCustomBuilder(
           String methodName, List<Type> parameterTypes,
           Class<?> entityClass, MethodNameInfo info);
 
-  private int metchSize(String name) {
-    for (String prefix : prefixs()) {
+  private int matchSize(String name) {
+    for (String prefix : prefixes()) {
       if (Strings.isEmpty(prefix)) {
         throw new IllegalStateException("prefix can't be empty");
       }
@@ -74,7 +74,7 @@ public abstract class AbstractNamedBuilderFactory extends BuilderFactory {
 
   protected void buildWhereClause(
       StringBuilder tailOfSql, List<OpUnit> opUnits, List<String> logics,
-      CrudMeta cm, List<Type> parameterTypes, String methodName, Class<?> clazz) {
+      CrudMeta cm, List<Type> parameterTypes, String methodName, Class<?> className) {
     if (opUnits.size() == 0) {
       throw new IllegalStateException(); // TODO msg
     }
@@ -98,7 +98,7 @@ public abstract class AbstractNamedBuilderFactory extends BuilderFactory {
       Type propertyType = cm.getTypeByProperty(property);
       if (column == null || propertyType == null) {
         throw new CrudException("the name of method [" + methodName + "] is error, " +
-            "property " + property + " can't be found in '" + clazz + "'");
+            "property " + property + " can't be found in '" + className + "'");
       }
       Op op = opUnit.getOp();
       String[] params = new String[op.paramCount()];

--- a/src/main/java/org/jfaster/mango/crud/named/factory/NamedCountBuilderFactory.java
+++ b/src/main/java/org/jfaster/mango/crud/named/factory/NamedCountBuilderFactory.java
@@ -31,14 +31,14 @@ import java.util.List;
  */
 public class NamedCountBuilderFactory extends AbstractNamedBuilderFactory {
 
-  private final static List<String> PREFIXS = new ArrayList<String>();
+  private static final List<String> PREFIXES = new ArrayList<String>();
   static {
-    PREFIXS.add("countBy");
+    PREFIXES.add("countBy");
   }
 
   @Override
-  public List<String> prefixs() {
-    return PREFIXS;
+  public List<String> prefixes() {
+    return PREFIXES;
   }
 
   @Override

--- a/src/main/java/org/jfaster/mango/crud/named/factory/NamedDeleteBuilderFactory.java
+++ b/src/main/java/org/jfaster/mango/crud/named/factory/NamedDeleteBuilderFactory.java
@@ -31,15 +31,15 @@ import java.util.List;
  */
 public class NamedDeleteBuilderFactory extends AbstractNamedBuilderFactory {
 
-  private final static List<String> PREFIXS = new ArrayList<String>();
+  private static final List<String> PREFIXES = new ArrayList<String>();
   static {
-    PREFIXS.add("deleteBy");
-    PREFIXS.add("removeBy");
+    PREFIXES.add("deleteBy");
+    PREFIXES.add("removeBy");
   }
 
   @Override
-  public List<String> prefixs() {
-    return PREFIXS;
+  public List<String> prefixes() {
+    return PREFIXES;
   }
 
   @Override

--- a/src/main/java/org/jfaster/mango/crud/named/factory/NamedQueryBuilderFactory.java
+++ b/src/main/java/org/jfaster/mango/crud/named/factory/NamedQueryBuilderFactory.java
@@ -30,17 +30,17 @@ import java.util.List;
  */
 public class NamedQueryBuilderFactory extends AbstractNamedBuilderFactory {
 
-  private final static List<String> PREFIXS = new ArrayList<String>();
+  private static final List<String> PREFIXES = new ArrayList<String>();
   static {
-    PREFIXS.add("getBy");
-    PREFIXS.add("findBy");
-    PREFIXS.add("queryBy");
-    PREFIXS.add("selectBy");
+    PREFIXES.add("getBy");
+    PREFIXES.add("findBy");
+    PREFIXES.add("queryBy");
+    PREFIXES.add("selectBy");
   }
 
   @Override
-  public List<String> prefixs() {
-    return PREFIXS;
+  public List<String> prefixes() {
+    return PREFIXES;
   }
 
   @Override

--- a/src/main/java/org/jfaster/mango/datasource/AbstractDataSourceFactory.java
+++ b/src/main/java/org/jfaster/mango/datasource/AbstractDataSourceFactory.java
@@ -21,12 +21,12 @@ package org.jfaster.mango.datasource;
  */
 public abstract class AbstractDataSourceFactory implements DataSourceFactory {
 
-  public final static String DEFULT_NAME = "DEFAULT";
+  public static final String DEFAULT_NAME = "DEFAULT";
 
   private String name;
 
   protected AbstractDataSourceFactory() {
-    this(DEFULT_NAME);
+    this(DEFAULT_NAME);
   }
 
   protected AbstractDataSourceFactory(String name) {

--- a/src/main/java/org/jfaster/mango/operator/BatchUpdateOperator.java
+++ b/src/main/java/org/jfaster/mango/operator/BatchUpdateOperator.java
@@ -53,13 +53,13 @@ public class BatchUpdateOperator extends AbstractOperator {
       return transformer.transform(new int[]{});
     }
 
-    Map<DataSource, Group> gorupMap = new HashMap<DataSource, Group>();
+    Map<DataSource, Group> groupMap = new HashMap<DataSource, Group>();
     int t = 0;
     for (Object obj : iterObj) {
       InvocationContext context = invocationContextFactory.newInvocationContext(new Object[]{obj});
-      group(context, gorupMap, t++);
+      group(context, groupMap, t++);
     }
-    int[] ints = executeDb(gorupMap, t);
+    int[] ints = executeDb(groupMap, t);
     return transformer.transform(ints);
   }
 

--- a/src/main/java/org/jfaster/mango/transaction/TransactionFactory.java
+++ b/src/main/java/org/jfaster/mango/transaction/TransactionFactory.java
@@ -60,11 +60,11 @@ public abstract class TransactionFactory {
   }
 
   public static Transaction newTransaction(TransactionIsolationLevel level) {
-    return newTransaction(AbstractDataSourceFactory.DEFULT_NAME, level);
+    return newTransaction(AbstractDataSourceFactory.DEFAULT_NAME, level);
   }
 
   public static Transaction newTransaction() {
-    return newTransaction(AbstractDataSourceFactory.DEFULT_NAME, TransactionIsolationLevel.DEFAULT);
+    return newTransaction(AbstractDataSourceFactory.DEFAULT_NAME, TransactionIsolationLevel.DEFAULT);
   }
 
   public static Transaction newTransaction(DataSource dataSource) {

--- a/src/main/java/org/jfaster/mango/util/logging/FormattingTuple.java
+++ b/src/main/java/org/jfaster/mango/util/logging/FormattingTuple.java
@@ -45,9 +45,9 @@ class FormattingTuple {
     if (argArray == null || argArray.length == 0) {
       throw new IllegalStateException("non-sensical empty or null argument array");
     }
-    final int trimemdLen = argArray.length - 1;
-    Object[] trimmed = new Object[trimemdLen];
-    System.arraycopy(argArray, 0, trimmed, 0, trimemdLen);
+    final int trimmedLen = argArray.length - 1;
+    Object[] trimmed = new Object[trimmedLen];
+    System.arraycopy(argArray, 0, trimmed, 0, trimmedLen);
     return trimmed;
   }
 

--- a/src/test/java/org/jfaster/mango/jdbc/exception/BadSqlGrammarExceptionTest.java
+++ b/src/test/java/org/jfaster/mango/jdbc/exception/BadSqlGrammarExceptionTest.java
@@ -49,7 +49,7 @@ public class BadSqlGrammarExceptionTest {
   public void test() {
     thrown.expect(BadSqlGrammarException.class);
     JdbcTemplate t = new JdbcTemplate();
-    BoundSql boundSql = new BoundSql(new StringBuilder("insert intoo .."));
+    BoundSql boundSql = new BoundSql(new StringBuilder("insert into .."));
     t.update(ds, boundSql);
   }
 

--- a/src/test/java/org/jfaster/mango/support/MockDB.java
+++ b/src/test/java/org/jfaster/mango/support/MockDB.java
@@ -26,7 +26,7 @@ import java.lang.annotation.Annotation;
  */
 public class MockDB implements Annotation, DB {
 
-  private String name = AbstractDataSourceFactory.DEFULT_NAME;
+  private String name = AbstractDataSourceFactory.DEFAULT_NAME;
 
   private String table = "";
 

--- a/src/test/java/org/jfaster/mango/transaction/TransactionTemplateTest.java
+++ b/src/test/java/org/jfaster/mango/transaction/TransactionTemplateTest.java
@@ -56,17 +56,17 @@ public class TransactionTemplateTest {
     dao.insert(y);
     dao.insert(z);
 
-    TransactionTemplate.execute(mango, AbstractDataSourceFactory.DEFULT_NAME, new TransactionAction() {
+    TransactionTemplate.execute(mango, AbstractDataSourceFactory.DEFAULT_NAME, new TransactionAction() {
       @Override
       public void doInTransaction(TransactionStatus status) {
         x.add(50);
         dao.update(x);
 
-        TransactionTemplate.execute(mango, AbstractDataSourceFactory.DEFULT_NAME, new TransactionAction() {
+        TransactionTemplate.execute(mango, AbstractDataSourceFactory.DEFAULT_NAME, new TransactionAction() {
 
           @Override
           public void doInTransaction(TransactionStatus status) {
-            TransactionTemplate.execute(mango, AbstractDataSourceFactory.DEFULT_NAME, new TransactionAction() {
+            TransactionTemplate.execute(mango, AbstractDataSourceFactory.DEFAULT_NAME, new TransactionAction() {
 
               @Override
               public void doInTransaction(TransactionStatus status) {
@@ -96,17 +96,17 @@ public class TransactionTemplateTest {
     dao.insert(y);
     dao.insert(z);
 
-    TransactionTemplate.execute(mango, AbstractDataSourceFactory.DEFULT_NAME, new TransactionAction() {
+    TransactionTemplate.execute(mango, AbstractDataSourceFactory.DEFAULT_NAME, new TransactionAction() {
       @Override
       public void doInTransaction(TransactionStatus status) {
         x.add(50);
         dao.update(x);
 
-        TransactionTemplate.execute(mango, AbstractDataSourceFactory.DEFULT_NAME, new TransactionAction() {
+        TransactionTemplate.execute(mango, AbstractDataSourceFactory.DEFAULT_NAME, new TransactionAction() {
 
           @Override
           public void doInTransaction(TransactionStatus status) {
-            TransactionTemplate.execute(mango, AbstractDataSourceFactory.DEFULT_NAME, new TransactionAction() {
+            TransactionTemplate.execute(mango, AbstractDataSourceFactory.DEFAULT_NAME, new TransactionAction() {
 
               @Override
               public void doInTransaction(TransactionStatus status) {
@@ -141,17 +141,17 @@ public class TransactionTemplateTest {
     dao.insert(y);
     dao.insert(z);
 
-    TransactionTemplate.execute(mango, AbstractDataSourceFactory.DEFULT_NAME, new TransactionAction() {
+    TransactionTemplate.execute(mango, AbstractDataSourceFactory.DEFAULT_NAME, new TransactionAction() {
       @Override
       public void doInTransaction(TransactionStatus status) {
         x.add(50);
         dao.update(x);
 
-        TransactionTemplate.execute(mango, AbstractDataSourceFactory.DEFULT_NAME, new TransactionAction() {
+        TransactionTemplate.execute(mango, AbstractDataSourceFactory.DEFAULT_NAME, new TransactionAction() {
 
           @Override
           public void doInTransaction(TransactionStatus status) {
-            TransactionTemplate.execute(mango, AbstractDataSourceFactory.DEFULT_NAME, new TransactionAction() {
+            TransactionTemplate.execute(mango, AbstractDataSourceFactory.DEFAULT_NAME, new TransactionAction() {
 
               @Override
               public void doInTransaction(TransactionStatus status) {

--- a/src/test/java/org/jfaster/mango/transaction/TransactionTest.java
+++ b/src/test/java/org/jfaster/mango/transaction/TransactionTest.java
@@ -66,7 +66,7 @@ public class TransactionTest {
     x.add(num);
     y.sub(num);
     TransactionIsolationLevel level = TransactionIsolationLevel.SERIALIZABLE;
-    Transaction tx = TransactionFactory.newTransaction(mango, AbstractDataSourceFactory.DEFULT_NAME, level);
+    Transaction tx = TransactionFactory.newTransaction(mango, AbstractDataSourceFactory.DEFAULT_NAME, level);
     ConnectionHolder connHolder = TransactionSynchronizationManager.getConnectionHolder(ds);
     assertThat(connHolder, notNullValue());
     assertThat(connHolder.getConnection(), notNullValue());
@@ -100,7 +100,7 @@ public class TransactionTest {
     x.add(num);
     y.sub(num);
     TransactionIsolationLevel level = TransactionIsolationLevel.SERIALIZABLE;
-    Transaction tx = TransactionFactory.newTransaction(mango, AbstractDataSourceFactory.DEFULT_NAME, level);
+    Transaction tx = TransactionFactory.newTransaction(mango, AbstractDataSourceFactory.DEFAULT_NAME, level);
     ConnectionHolder connHolder = TransactionSynchronizationManager.getConnectionHolder(ds);
     assertThat(connHolder, notNullValue());
     assertThat(connHolder.getConnection(), notNullValue());
@@ -136,7 +136,7 @@ public class TransactionTest {
     x.add(num);
     y.sub(num);
     TransactionIsolationLevel level = TransactionIsolationLevel.SERIALIZABLE;
-    Transaction tx = TransactionFactory.newTransaction(mango, AbstractDataSourceFactory.DEFULT_NAME, level);
+    Transaction tx = TransactionFactory.newTransaction(mango, AbstractDataSourceFactory.DEFAULT_NAME, level);
     ConnectionHolder connHolder = TransactionSynchronizationManager.getConnectionHolder(ds);
     assertThat(connHolder, notNullValue());
     assertThat(connHolder.getConnection(), notNullValue());
@@ -163,7 +163,7 @@ public class TransactionTest {
     int previousLevel = getPreviousLevel();
 
     TransactionIsolationLevel level = TransactionIsolationLevel.SERIALIZABLE;
-    Transaction tx = TransactionFactory.newTransaction(mango, AbstractDataSourceFactory.DEFULT_NAME, level);
+    Transaction tx = TransactionFactory.newTransaction(mango, AbstractDataSourceFactory.DEFAULT_NAME, level);
     ConnectionHolder connHolder = TransactionSynchronizationManager.getConnectionHolder(ds);
     assertThat(connHolder, notNullValue());
     assertThat(connHolder.getConnection(), notNullValue());
@@ -183,7 +183,7 @@ public class TransactionTest {
     int previousLevel = getPreviousLevel();
 
     TransactionIsolationLevel level = TransactionIsolationLevel.SERIALIZABLE;
-    Transaction tx = TransactionFactory.newTransaction(mango, AbstractDataSourceFactory.DEFULT_NAME, level);
+    Transaction tx = TransactionFactory.newTransaction(mango, AbstractDataSourceFactory.DEFAULT_NAME, level);
     ConnectionHolder connHolder = TransactionSynchronizationManager.getConnectionHolder(ds);
     assertThat(connHolder, notNullValue());
     assertThat(connHolder.getConnection(), notNullValue());
@@ -209,7 +209,7 @@ public class TransactionTest {
     x.add(num);
     y.sub(num);
 
-    Transaction tx = TransactionFactory.newTransaction(mango, AbstractDataSourceFactory.DEFULT_NAME);
+    Transaction tx = TransactionFactory.newTransaction(mango, AbstractDataSourceFactory.DEFAULT_NAME);
     ConnectionHolder connHolder = TransactionSynchronizationManager.getConnectionHolder(ds);
 
     dao.update(x);


### PR DESCRIPTION
- **AbstractDataSourceFactory** - rename `DEFULT_NAME` to `DEFAULT_NAME`,
    changed at all occurrences.
- **BadSqlGrammarExceptionTest** - change typo in log from "intoo" to
    "into".
- **BatchUpdateOperator** - rename `gorupMap` to `groupMap`,
    changed at all occurrences.
- **FormattingTuple** - rename `trimemdLen` to `trimmedLen`,
    changed at all occurrences.
- **AbstractNamedBuilderFactory**:
  - rename `metchSize` to `matchSize`.
  - rename `prefixs` to `prefixes`.
  - rename `clazz` to `className`.
  - changed at all occurrences.
- **NamedCountBuilderFactory**, **NamedDeleteBuilderFactory** and **NamedQueryBuilderFactory**:
  - rename `PREFIX` to `PREFIXES`.
  - changed at all occurrences.