### PR TITLE
refactor: extract a new class from Strings

### DIFF
--- a/src/main/java/org/jfaster/mango/binding/BindingParameter.java
+++ b/src/main/java/org/jfaster/mango/binding/BindingParameter.java
@@ -16,6 +16,7 @@
 
 package org.jfaster.mango.binding;
 
+import org.jfaster.mango.util.ManipulateStringNames;
 import org.jfaster.mango.util.Objects;
 import org.jfaster.mango.util.Strings;
 import org.jfaster.mango.util.jdbc.JdbcType;
@@ -61,7 +62,7 @@ public class BindingParameter {
   }
 
   public String getFullName() {
-    return Strings.getFullName(parameterName, propertyName);
+    return ManipulateStringNames.getFullName(parameterName, propertyName);
   }
 
   public boolean hasProperty() {

--- a/src/main/java/org/jfaster/mango/crud/CrudMeta.java
+++ b/src/main/java/org/jfaster/mango/crud/CrudMeta.java
@@ -17,6 +17,7 @@
 package org.jfaster.mango.crud;
 
 import org.jfaster.mango.annotation.*;
+import org.jfaster.mango.util.ManipulateStringNames;
 import org.jfaster.mango.util.Strings;
 import org.jfaster.mango.util.bean.BeanUtil;
 import org.jfaster.mango.util.bean.PropertyMeta;
@@ -68,7 +69,7 @@ public class CrudMeta {
       Column colAnno = propertyMeta.getPropertyAnno(Column.class);
       String col = colAnno != null ?
           colAnno.value() :
-          Strings.underscoreName(prop);
+          ManipulateStringNames.underscoreName(prop);
       props.add(prop);
       cols.add(col);
       propToColMap.put(prop, col);

--- a/src/main/java/org/jfaster/mango/crud/named/parser/MethodNameParser.java
+++ b/src/main/java/org/jfaster/mango/crud/named/parser/MethodNameParser.java
@@ -16,6 +16,7 @@
 
 package org.jfaster.mango.crud.named.parser;
 
+import org.jfaster.mango.util.ManipulateStringNames;
 import org.jfaster.mango.util.Strings;
 
 import javax.annotation.Nullable;
@@ -51,7 +52,7 @@ public class MethodNameParser {
     int index = 0;
     while (m.find()) {
       opUnits.add(OpUnit.create(str.substring(index, m.start())));
-      logics.add(Strings.firstLetterToLowerCase(m.group()));
+      logics.add(ManipulateStringNames.firstLetterToLowerCase(m.group()));
       index = m.end();
     }
     opUnits.add(OpUnit.create(str.substring(index)));
@@ -63,7 +64,7 @@ public class MethodNameParser {
     Pattern p = Pattern.compile(ORDER_BY_REGEX);
     Matcher m = p.matcher(str);
     if (m.find()) {
-      String tailStr = Strings.firstLetterToLowerCase(str.substring(m.end() - 1));
+      String tailStr = ManipulateStringNames.firstLetterToLowerCase(str.substring(m.end() - 1));
       int size = ORDER_BY.length() + tailStr.length();
       String property;
       OrderType orderType;

--- a/src/main/java/org/jfaster/mango/crud/named/parser/OpUnit.java
+++ b/src/main/java/org/jfaster/mango/crud/named/parser/OpUnit.java
@@ -17,6 +17,7 @@
 package org.jfaster.mango.crud.named.parser;
 
 import org.jfaster.mango.crud.named.parser.op.*;
+import org.jfaster.mango.util.ManipulateStringNames;
 import org.jfaster.mango.util.Strings;
 
 import java.util.ArrayList;
@@ -53,12 +54,12 @@ public class OpUnit {
     for (Op op : OPS) {
       if (str.endsWith(op.keyword())) {
         this.op = op;
-        this.property = Strings.firstLetterToLowerCase(str.substring(0, str.length() - op.keyword().length()));
+        this.property = ManipulateStringNames.firstLetterToLowerCase(str.substring(0, str.length() - op.keyword().length()));
         return;
       }
     }
     this.op = new EqualsOp();
-    this.property = Strings.firstLetterToLowerCase(str);
+    this.property = ManipulateStringNames.firstLetterToLowerCase(str);
   }
 
   public static OpUnit create(String str) {

--- a/src/main/java/org/jfaster/mango/mapper/BeanPropertyRowMapper.java
+++ b/src/main/java/org/jfaster/mango/mapper/BeanPropertyRowMapper.java
@@ -20,6 +20,7 @@ import org.jfaster.mango.invoker.InvokerCache;
 import org.jfaster.mango.invoker.TransferableInvoker;
 import org.jfaster.mango.type.TypeHandler;
 import org.jfaster.mango.type.TypeHandlerRegistry;
+import org.jfaster.mango.util.ManipulateStringNames;
 import org.jfaster.mango.util.PropertyTokenizer;
 import org.jfaster.mango.util.Strings;
 import org.jfaster.mango.util.jdbc.ResultSetWrapper;
@@ -78,7 +79,7 @@ public class BeanPropertyRowMapper<T> implements RowMapper<T> {
         invokerMap.put(column.toLowerCase(), invoker);
       } else { // 使用约定映射
         invokerMap.put(invoker.getName().toLowerCase(), invoker);
-        String underscoredName = Strings.underscoreName(invoker.getName());
+        String underscoredName = ManipulateStringNames.underscoreName(invoker.getName());
         if (!invoker.getName().toLowerCase().equals(underscoredName)) {
           invokerMap.put(underscoredName, invoker);
         }

--- a/src/main/java/org/jfaster/mango/util/ManipulateStringNames.java
+++ b/src/main/java/org/jfaster/mango/util/ManipulateStringNames.java
@@ -1,0 +1,36 @@
+package org.jfaster.mango.util;
+
+public class ManipulateStringNames {
+  private ManipulateStringNames() {
+  }
+
+  public static String getFullName(String name, String path) {
+    return ":" + (Strings.isNotEmpty(path) ? name + "." + path : name);
+  }
+
+  public static String underscoreName(String name) {
+    if (Strings.isEmpty(name)) {
+      return "";
+    }
+    StringBuilder result = new StringBuilder();
+    result.append(name.substring(0, 1).toLowerCase());
+    for (int i = 1; i < name.length(); i++) {
+      String s = name.substring(i, i + 1);
+      String slc = s.toLowerCase();
+      if (!s.equals(slc)) {
+        result.append("_").append(slc);
+      } else {
+        result.append(s);
+      }
+    }
+    return result.toString();
+  }
+
+  public static String firstLetterToLowerCase(String str) {
+    return str.substring(0, 1).toLowerCase() + str.substring(1);
+  }
+
+  public static String firstLetterToUpperCase(String str) {
+    return str.substring(0, 1).toUpperCase() + str.substring(1);
+  }
+}

--- a/src/main/java/org/jfaster/mango/util/Strings.java
+++ b/src/main/java/org/jfaster/mango/util/Strings.java
@@ -36,34 +36,4 @@ public class Strings {
     return isEmpty(string) ? null : string;
   }
 
-  public static String getFullName(String name, String path) {
-    return ":" + (Strings.isNotEmpty(path) ? name + "." + path : name);
-  }
-
-  public static String underscoreName(String name) {
-    if (Strings.isEmpty(name)) {
-      return "";
-    }
-    StringBuilder result = new StringBuilder();
-    result.append(name.substring(0, 1).toLowerCase());
-    for (int i = 1; i < name.length(); i++) {
-      String s = name.substring(i, i + 1);
-      String slc = s.toLowerCase();
-      if (!s.equals(slc)) {
-        result.append("_").append(slc);
-      } else {
-        result.append(s);
-      }
-    }
-    return result.toString();
-  }
-
-  public static String firstLetterToLowerCase(String str) {
-    return str.substring(0, 1).toLowerCase() + str.substring(1);
-  }
-
-  public static String firstLetterToUpperCase(String str) {
-    return str.substring(0, 1).toUpperCase() + str.substring(1);
-  }
-
 }

--- a/src/main/java/org/jfaster/mango/util/bean/BeanUtil.java
+++ b/src/main/java/org/jfaster/mango/util/bean/BeanUtil.java
@@ -17,6 +17,7 @@
 package org.jfaster.mango.util.bean;
 
 import org.jfaster.mango.exception.UncheckedException;
+import org.jfaster.mango.util.ManipulateStringNames;
 import org.jfaster.mango.util.Strings;
 import org.jfaster.mango.util.local.CacheLoader;
 import org.jfaster.mango.util.local.DoubleCheckCache;
@@ -61,7 +62,7 @@ public class BeanUtil {
                   Type type = readMethod.getGenericReturnType(); // 和writeMethod的type相同
                   Field field = tryGetField(readMethod.getDeclaringClass(), name);
                   if (isBoolean(pd.getPropertyType()) && field == null) {
-                    String bname = "is" + Strings.firstLetterToUpperCase(name);
+                    String bname = "is" + ManipulateStringNames.firstLetterToUpperCase(name);
                     field = tryGetField(clazz, bname);
                     if (field != null) {
                       name = bname;  // 使用isXxYy替换xxYy

--- a/src/test/java/org/jfaster/mango/util/bean/BeanUtilTest.java
+++ b/src/test/java/org/jfaster/mango/util/bean/BeanUtilTest.java
@@ -19,6 +19,7 @@ package org.jfaster.mango.util.bean;
 import com.google.common.collect.Sets;
 import org.jfaster.mango.annotation.Column;
 import org.jfaster.mango.annotation.ID;
+import org.jfaster.mango.util.ManipulateStringNames;
 import org.jfaster.mango.util.Strings;
 import org.junit.Test;
 
@@ -64,8 +65,8 @@ public class BeanUtilTest {
   }
 
   private PropertyMeta getPropertyMeta(Class<?> clazz, String property, Class<?> type) throws NoSuchMethodException {
-    String readMethodName = "get" + Strings.firstLetterToUpperCase(property);
-    String writeMethodName = "set" + Strings.firstLetterToUpperCase(property);
+    String readMethodName = "get" + ManipulateStringNames.firstLetterToUpperCase(property);
+    String writeMethodName = "set" + ManipulateStringNames.firstLetterToUpperCase(property);
     Method readMethod = clazz.getMethod(readMethodName);
     Method writeMethod = clazz.getMethod(writeMethodName, type);
     Field f = tryGetField(clazz, property);


### PR DESCRIPTION
- The Strings class had functions to manipulate names.
- To facilitate easier code changes, the functions related the
  manipulation of names are made into a new class that deals with just
  name manipulations - ManipulateStringNames.
- This helps to add/change utility methods for both strings and names.
- Helps improve cohesion of both the classes (Strings and
  ManipulateStringNames).