### PR TITLE
refactor(CustomCrudDaoTest, PageTest): move method

### DIFF
--- a/src/test/java/org/jfaster/mango/crud/CustomCrudDaoTest.java
+++ b/src/test/java/org/jfaster/mango/crud/CustomCrudDaoTest.java
@@ -43,7 +43,7 @@ import static org.hamcrest.Matchers.equalTo;
 public class CustomCrudDaoTest {
 
   private final static DataSource ds = DataSourceConfig.getDataSource();
-  private final static Mango mango = Mango.newInstance(ds);
+  public final static Mango mango = Mango.newInstance(ds);
 
   @Before
   public void before() throws Exception {
@@ -72,25 +72,6 @@ public class CustomCrudDaoTest {
     assertThat(dao.countByUserId(userId), equalTo(2));
     assertThat(dao.deleteByUserId(userId), equalTo(2));
     assertThat(dao.countByUserId(userId), equalTo(0));
-  }
-
-  @Test
-  public void testPage() throws Exception {
-    CrudOrderDao dao = mango.create(CrudOrderDao.class);
-    int userId = 2;
-    for (int i = 0; i < 10; i++) {
-      CrudOrder order = CrudOrder.createRandomCrudOrder(userId);
-      dao.add(order);
-    }
-    assertThat(dao.getByUserId(userId, Page.of(0, 3)).size(), equalTo(3));
-
-    assertThat(dao.getByUserId(userId, Page.of(1, 3)).size(), equalTo(3));
-
-    assertThat(dao.getByUserId(userId, Page.of(2, 3)).size(), equalTo(3));
-
-    PageResult<CrudOrder> pr = dao.findByUserId(userId, Page.of(3, 3));
-    assertThat(pr.getData().size(), equalTo(1));
-    assertThat(pr.getTotal(), equalTo(10L));
   }
 
   @Rule
@@ -133,7 +114,7 @@ public class CustomCrudDaoTest {
   }
 
   @DB(table = "t_order")
-  interface CrudOrderDao extends CrudDao<CrudOrder, String> {
+  public interface CrudOrderDao extends CrudDao<CrudOrder, String> {
 
     CrudOrder getById(String id);
 

--- a/src/test/java/org/jfaster/mango/page/PageTest.java
+++ b/src/test/java/org/jfaster/mango/page/PageTest.java
@@ -16,10 +16,14 @@
 
 package org.jfaster.mango.page;
 
+import org.jfaster.mango.crud.CrudOrder;
+import org.jfaster.mango.crud.CustomCrudDaoTest;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.jfaster.mango.crud.CustomCrudDaoTest.mango;
 
 /**
  * @author ash
@@ -37,6 +41,25 @@ public class PageTest {
     assertThat(page.getPageNum(), is(2));
     assertThat(page.getPageSize(), is(200));
 
+  }
+
+  @Test
+  public void testPage() throws Exception {
+    CustomCrudDaoTest.CrudOrderDao dao = mango.create(CustomCrudDaoTest.CrudOrderDao.class);
+    int userId = 2;
+    for (int i = 0; i < 10; i++) {
+      CrudOrder order = CrudOrder.createRandomCrudOrder(userId);
+      dao.add(order);
+    }
+    assertThat(dao.getByUserId(userId, Page.of(0, 3)).size(), equalTo(3));
+
+    assertThat(dao.getByUserId(userId, Page.of(1, 3)).size(), equalTo(3));
+
+    assertThat(dao.getByUserId(userId, Page.of(2, 3)).size(), equalTo(3));
+
+    PageResult<CrudOrder> pr = dao.findByUserId(userId, Page.of(3, 3));
+    assertThat(pr.getData().size(), equalTo(1));
+    assertThat(pr.getTotal(), equalTo(10L));
   }
 
 }


### PR DESCRIPTION
- The method testPage() is moved from CustomCrudDaoTest to PageTest to put the test in its correct place and also make the classes more cohesive.
- No test has been deleted.